### PR TITLE
Unify the config loading between sbt and runtime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,8 @@ def noPublish: Seq[Setting[_]] = Seq(
 def playEbeanDeps = Seq(
   "com.typesafe.play" %% "play-java-jdbc" % PlayVersion,
   "org.avaje.ebeanorm" % "avaje-ebeanorm" % "4.5.6",
-  avajeEbeanormAgent
+  avajeEbeanormAgent,
+  "com.typesafe.play" %% "play-test" % PlayVersion % Test
 )
 
 def sbtPlayEbeanDeps = Seq(

--- a/play-ebean/src/main/java/play/db/ebean/EbeanParsedConfig.java
+++ b/play-ebean/src/main/java/play/db/ebean/EbeanParsedConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.db.ebean;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueType;
+import play.Configuration;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The raw parsed config from Ebean, as opposed to the EbeanConfig which actually requires starting database connection
+ * pools to create.
+ */
+public class EbeanParsedConfig {
+
+    private final String defaultDatasource;
+    private final Map<String, List<String>> datasourceModels;
+
+    public EbeanParsedConfig(String defaultDatasource, Map<String, List<String>> datasourceModels) {
+        this.defaultDatasource = defaultDatasource;
+        this.datasourceModels = datasourceModels;
+    }
+
+    public String getDefaultDatasource() {
+        return defaultDatasource;
+    }
+
+    public Map<String, List<String>> getDatasourceModels() {
+        return datasourceModels;
+    }
+
+    public static EbeanParsedConfig parseFromConfig(Configuration configuration) {
+        Config config = configuration.underlying();
+        Config playEbeanConfig = config.getConfig("play.ebean");
+        String defaultDatasource = playEbeanConfig.getString("defaultDatasource");
+        String ebeanConfigKey = playEbeanConfig.getString("config");
+
+        Map<String, List<String>> datasourceModels = new HashMap<>();
+
+        if (config.hasPath(ebeanConfigKey)) {
+            Config ebeanConfig = config.getConfig(ebeanConfigKey);
+
+            for (String key : ebeanConfig.root().keySet()) {
+
+                ConfigValue raw = ebeanConfig.getValue(key);
+                List<String> models;
+                if (raw.valueType() == ConfigValueType.STRING) {
+                    // Support legacy comma separated string
+                    models = Arrays.asList(((String) raw.unwrapped()).split(","));
+                } else {
+                    models = ebeanConfig.getStringList(key);
+                }
+
+                datasourceModels.put(key, models);
+
+            }
+        }
+        return new EbeanParsedConfig(defaultDatasource, datasourceModels);
+    }
+}

--- a/play-ebean/src/main/java/play/db/ebean/ModelsConfigLoader.java
+++ b/play-ebean/src/main/java/play/db/ebean/ModelsConfigLoader.java
@@ -1,0 +1,25 @@
+package play.db.ebean;
+
+import play.Configuration;
+import play.Environment;
+import play.Mode;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Given a classloader, load the models configuration.
+ *
+ * This is used by the ebean sbt plugin to get the same models configuration that will be loaded by the app.
+ */
+public class ModelsConfigLoader implements Function<ClassLoader, Map<String, List<String>>> {
+
+    @Override
+    public  Map<String, List<String>> apply(ClassLoader classLoader) {
+        Environment env = new Environment(new File("."), classLoader, Mode.PROD);
+        Configuration config = Configuration.load(env);
+        return EbeanParsedConfig.parseFromConfig(config).getDatasourceModels();
+    }
+}

--- a/play-ebean/src/test/java/play/db/ebean/EbeanParsedConfigTest.java
+++ b/play-ebean/src/test/java/play/db/ebean/EbeanParsedConfigTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.db.ebean;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.ConfigFactory;
+import play.Configuration;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.*;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+
+public class EbeanParsedConfigTest {
+
+    private EbeanParsedConfig parse(Map<String, ? extends Object> config) {
+        return EbeanParsedConfig.parseFromConfig(
+                new Configuration(ConfigFactory.parseMap(config).withFallback(ConfigFactory.defaultReference()))
+        );
+    }
+
+    @Test
+    public void defaultConfig() {
+        EbeanParsedConfig config = parse(Collections.emptyMap());
+        assertThat(config.getDefaultDatasource(), equalTo("default"));
+        assertThat(config.getDatasourceModels().size(), equalTo(0));
+    }
+
+    @Test
+    public void withDatasources() {
+        EbeanParsedConfig config = parse(ImmutableMap.of(
+                "ebean.default", Arrays.asList("a", "b"),
+                "ebean.other", Arrays.asList("c")
+        ));
+        assertThat(config.getDatasourceModels().size(), equalTo(2));
+        assertThat(config.getDatasourceModels().get("default"), hasItems("a", "b"));
+        assertThat(config.getDatasourceModels().get("other"), hasItems("c"));
+    }
+
+    @Test
+    public void commaSeparatedModels() {
+        EbeanParsedConfig config = parse(ImmutableMap.of(
+                "ebean.default", "a,b"
+        ));
+        assertThat(config.getDatasourceModels().get("default"), hasItems("a", "b"));
+    }
+
+    @Test
+    public void customDefault() {
+        EbeanParsedConfig config = parse(ImmutableMap.of(
+                "play.ebean.defaultDatasource", "custom"
+        ));
+        assertThat(config.getDefaultDatasource(), equalTo("custom"));
+    }
+
+    @Test
+    public void customConfig() {
+        EbeanParsedConfig config = parse(ImmutableMap.of(
+                "play.ebean.config", "my.custom",
+                "my.custom.default", Arrays.asList("a")
+        ));
+        assertThat(config.getDatasourceModels().size(), equalTo(1));
+        assertThat(config.getDatasourceModels().get("default"), hasItems("a"));
+    }
+
+
+}

--- a/sbt-play-ebean/src/sbt-test/sbt-ebean/enhancement/conf/application.conf
+++ b/sbt-play-ebean/src/sbt-test/sbt-ebean/enhancement/conf/application.conf
@@ -1,1 +1,1 @@
-ebean.default = "models.*"
+ebean.default = [ "models.*" ]


### PR DESCRIPTION
Fixes #18 - the sbt config loading wasn't updated to support lists

The way that the sbt plugin used to discover the models to enhance used to be roughly copied config loading mechanism from Play, followed by roughly copying the config lookup mechanism.  This unifies them, so it now uses *the* config loading mechanism from Play, and *the* play-ebean config lookup code.