### PR TITLE
Bumped Play version to minimum version required to compile

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import sbt.inc.Analysis
 
-val PlayVersion = sys.props.getOrElse("play.version", "2.4.0-RC2")
+val PlayVersion = sys.props.getOrElse("play.version", "2.4.0-2015-05-10-ed330de-SNAPSHOT")
 
 lazy val root = project
   .in(file("."))
@@ -160,6 +160,7 @@ def noPublish: Seq[Setting[_]] = Seq(
 
 def playEbeanDeps = Seq(
   "com.typesafe.play" %% "play-java-jdbc" % PlayVersion,
+  "com.typesafe.play" %% "play-jdbc-evolutions" % PlayVersion,
   "org.avaje.ebeanorm" % "avaje-ebeanorm" % "4.5.6",
   avajeEbeanormAgent,
   "com.typesafe.play" %% "play-test" % PlayVersion % Test


### PR DESCRIPTION
The version should be changed again once Play 2.4.0-RC3 is out.