### PR TITLE
Update plugin to use new version of ebean ORM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import sbt.inc.Analysis
 
-val PlayVersion = playVersion(sys.props.getOrElse("play.version", "2.4.0"))
+val PlayVersion = playVersion(sys.props.getOrElse("play.version", "2.4.2"))
 
 val PlayEnhancerVersion = "1.1.0"
 
@@ -56,7 +56,7 @@ playBuildExtraPublish := {
 def playEbeanDeps = Seq(
   "com.typesafe.play" %% "play-java-jdbc" % PlayVersion,
   "com.typesafe.play" %% "play-jdbc-evolutions" % PlayVersion,
-  "org.avaje.ebeanorm" % "avaje-ebeanorm" % "4.7.2",
+  "org.avaje.ebeanorm" % "avaje-ebeanorm" % "4.8.1",
   avajeEbeanormAgent,
   "com.typesafe.play" %% "play-test" % PlayVersion % Test
 )

--- a/docs/manual/working/javaGuide/main/sql/code/javaguide/ebean/Task.java
+++ b/docs/manual/working/javaGuide/main/sql/code/javaguide/ebean/Task.java
@@ -24,8 +24,6 @@ public class Task extends Model {
     @Formats.DateTime(pattern="dd/MM/yyyy")
     public Date dueDate = new Date();
 
-    public static Finder<Long,Task> find = new Finder<Long,Task>(
-            Long.class, Task.class
-    );
+    public static Finder<Long, Task> find = new Finder<Long,Task>(Task.class);
 }
 //#content


### PR DESCRIPTION
Ebean has released version 4.8.1 (see https://github.com/ebean-orm/avaje-ebeanorm/releases).  This release fixes an accidental API change that prevents listeners from being unloaded.  