### PR TITLE
Project compiles against Play master. Fix #49

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 jdk:
   - oraclejdk8
 script:
-  - sbt +test +publishLocal plugin/test plugin/scripted
+  - sbt test publishLocal plugin/test plugin/scripted
   - cd docs && sbt test validateDocs evaluateSbtFiles
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import sbt.inc.Analysis
 
-val PlayVersion = playVersion(sys.props.getOrElse("play.version", "2.4.2"))
+val PlayVersion = playVersion(sys.props.getOrElse("play.version", "2.5.0-M1"))
 
 val PlayEnhancerVersion = "1.1.0"
 

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,3 +1,5 @@
+SettingKey[Seq[File]]("migrationManualSources") := Nil
+
 lazy val docs = project
   .in(file("."))
   .enablePlugins(PlayDocsPlugin, PlayEnhancer)

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -8,7 +8,8 @@ lazy val docs = project
     PlayDocsKeys.javaManualSourceDirectories := (baseDirectory.value / "manual" / "working" / "javaGuide" ** "code").get,
     // No resource directories shuts the ebean agent up about java sources in the classes directory
     unmanagedResourceDirectories in Test := Nil,
-    parallelExecution in Test := false
+    parallelExecution in Test := false,
+    scalaVersion := "2.11.7"
   )
   .settings(PlayEbean.unscopedSettings: _*)
   .settings(inConfig(Test)(Seq(

--- a/docs/project/plugins.sbt
+++ b/docs/project/plugins.sbt
@@ -4,4 +4,4 @@ lazy val sbtPlayEbean = ProjectRef(Path.fileProperty("user.dir").getParentFile, 
 
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 
-addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.4.0-RC5"))
+addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.5.0-M1"))

--- a/play-ebean/src/main/java/play/db/ebean/TransactionalAction.java
+++ b/play-ebean/src/main/java/play/db/ebean/TransactionalAction.java
@@ -3,9 +3,10 @@
  */
 package play.db.ebean;
 
+import java.util.concurrent.CompletionStage;
+
 import com.avaje.ebean.Ebean;
 import com.avaje.ebean.TxCallable;
-import play.libs.F;
 import play.mvc.Action;
 import play.mvc.Http.Context;
 import play.mvc.Result;
@@ -14,19 +15,7 @@ import play.mvc.Result;
  * Wraps an action in an Ebean transaction.
  */
 public class TransactionalAction extends Action<Transactional> {
-    
-    public F.Promise<Result> call(final Context ctx) throws Throwable {
-        return Ebean.execute(new TxCallable<F.Promise<Result>>() {
-            public F.Promise<Result> call() {
-                try {
-                    return delegate.call(ctx);
-                } catch (RuntimeException e) {
-                    throw e;
-                } catch (Throwable t) {
-                    throw new RuntimeException(t);
-                }
-            }
-        });
+    public CompletionStage<Result> call(final Context ctx) {
+        return Ebean.execute(() -> delegate.call(ctx));
     }
-    
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("1.0.2"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("1.1.0"))

--- a/sbt-play-ebean/src/sbt-test/sbt-ebean/enhancement/build.sbt
+++ b/sbt-play-ebean/src/sbt-test/sbt-ebean/enhancement/build.sbt
@@ -2,6 +2,8 @@ lazy val root = project
   .in(file("."))
   .enablePlugins(PlayJava, PlayEbean)
 
+scalaVersion := "2.11.7"
+
 sourceDirectory in Test := baseDirectory.value / "tests"
 
 scalaSource in Test := baseDirectory.value / "tests"

--- a/sbt-play-ebean/src/sbt-test/sbt-ebean/model-loading/build.sbt
+++ b/sbt-play-ebean/src/sbt-test/sbt-ebean/model-loading/build.sbt
@@ -2,6 +2,8 @@ lazy val root = project
   .in(file("."))
   .enablePlugins(PlayJava, PlayEbean)
 
+scalaVersion := "2.11.7"
+
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 
 PlayKeys.playOmnidoc := false


### PR DESCRIPTION
Because `Action.call` does no longer declare to throw in its signature, there is
no need to wrap `Throwable` into a runtime exception.

This commit is related to https://github.com/playframework/playframework/commit/f9e2d1917019f2bb1b2876b464014640965bade1#diff-02a5773c77e32371d3322bbb15c320d7L27 (see playframework/playframework@f9e2d1917019f2bb1b2876b464014640965bade1)