### PR TITLE
Upgrade Ebean to prior version 9.1.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ playBuildExtraPublish := {
 def playEbeanDeps = Seq(
   "com.typesafe.play" %% "play-java-jdbc" % PlayVersion,
   "com.typesafe.play" %% "play-jdbc-evolutions" % PlayVersion,
-  "org.avaje.ebean" % "ebean" % "8.4.1",
+  "org.avaje.ebean" % "ebean" % "9.1.2",
   avajeEbeanormAgent,
   "com.typesafe.play" %% "play-test" % PlayVersion % Test
 )

--- a/play-ebean/src/main/java/play/db/ebean/DefaultEbeanConfig.java
+++ b/play-ebean/src/main/java/play/db/ebean/DefaultEbeanConfig.java
@@ -73,6 +73,7 @@ public class DefaultEbeanConfig implements EbeanConfig {
                 ServerConfig serverConfig = new ServerConfig();
                 serverConfig.setName(key);
                 serverConfig.loadFromProperties();
+                serverConfig.setH2ProductionMode(true);  // Since Ebean 9.1.1: Don't override Evolution
 
                 setServerConfigDataSource(key, serverConfig);
 


### PR DESCRIPTION
This pull request upgrade Ebean version to prior version 9.1.2 released since few days. This new Ebean version fix major issues :

- Can use Play with H2 Database and Ebean version 9.x
- Query cache collision
- Clash on bind hash value for query cache with consecutive values
- @AttributeOverride (not wrapped in @AttributeOverrides) is not applied
- DBMigration Generates wrong ddl for UUID type

More information about Ebean 9.1.2 at https://github.com/ebean-orm/ebean/releases