### PR TITLE
Fix Default server status

### DIFF
--- a/play-ebean/src/main/java/play/db/ebean/DefaultEbeanConfig.java
+++ b/play-ebean/src/main/java/play/db/ebean/DefaultEbeanConfig.java
@@ -78,8 +78,8 @@ public class DefaultEbeanConfig implements EbeanConfig {
 
                 setServerConfigDataSource(key, serverConfig);
 
-                if (ebeanConfig.getDefaultDatasource().equals(key)) {
-                    serverConfig.setDefaultServer(true);
+                if (!ebeanConfig.getDefaultDatasource().equals(key)) {
+                    serverConfig.setDefaultServer(false);
                 }
 
                 Set<String> classes = getModelClasses(entry);


### PR DESCRIPTION
In ServerConfig class, default value of the attribute defaultServer is true. So we have to change it to false when ebeanConfig.getDefaultDatasource() is not equals to the config key