### PR TITLE
Update plugin version in documentation

### DIFF
--- a/docs/manual/working/javaGuide/main/sql/code/ebean.sbt
+++ b/docs/manual/working/javaGuide/main/sql/code/ebean.sbt
@@ -1,5 +1,5 @@
 //#add-sbt-plugin
-addSbtPlugin("com.typesafe.sbt" % "sbt-play-ebean" % "4.0.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-play-ebean" % "4.1.0")
 //#add-sbt-plugin
 
 //#enable-plugin


### PR DESCRIPTION
I updated the version in documentation. The main reason is that version 4.0.1 is not available for `Scala 2.12` and `Sbt 1.x`.

This is an issue for new users that starts from `playframework/play-java-seed.g8` that follows the documentation.