### PR TITLE
Update to Play 2.7.0-M1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,8 @@ val Versions = new {
   val typesafeConfig = "1.3.3"
 }
 
+val scala213Version = "2.13.0-M3"
+
 lazy val root = project
   .in(file("."))
   .enablePlugins(PlayRootProject, CrossPerProjectPlugin)
@@ -23,7 +25,7 @@ lazy val core = project
   .enablePlugins(Playdoc, PlayLibrary, JacocoPlugin)
   .settings(
     name := "play-ebean",
-    crossScalaVersions := Seq(scala211, scala212),
+    crossScalaVersions := Seq(scala211, scala212, scala213Version),
     libraryDependencies ++= playEbeanDeps,
     compile in Compile := enhanceEbeanClasses(
       (dependencyClasspath in Compile).value,

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ import sbt.inc.Analysis
 import interplay.ScalaVersions._
 
 val Versions = new {
-  val play: String = playVersion(sys.props.getOrElse("play.version", "2.6.13"))
+  val play: String = playVersion(sys.props.getOrElse("play.version", "2.7.0-M1"))
   val playEnhancer = "1.2.2"
-  val ebean = "11.15.4"
+  val ebean = "11.17.5"
   val ebeanAgent = "11.11.1"
   val typesafeConfig = "1.3.3"
 }
@@ -68,13 +68,19 @@ lazy val ebeanDeps = Seq(
   "io.ebean" % "ebean-agent" % Versions.ebeanAgent
 )
 
+lazy val reflectionDeps = Seq(
+  ("org.reflections" % "reflections" % "0.9.11")
+    .exclude("com.google.code.findbugs", "annotations")
+    .classifier("")
+)
+
 lazy val playEbeanDeps = ebeanDeps ++ Seq(
   "com.typesafe.play" %% "play-java-jdbc" % Versions.play,
   "com.typesafe.play" %% "play-jdbc-evolutions" % Versions.play,
   "com.typesafe.play" %% "play-guice" % Versions.play % Test,
   "com.typesafe.play" %% "filters-helpers" % Versions.play % Test,
   "com.typesafe.play" %% "play-test" % Versions.play % Test
-)
+) ++ reflectionDeps
 
 lazy val sbtPlayEbeanDeps = ebeanDeps ++ Seq(
   "com.typesafe" % "config" % Versions.typesafeConfig

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -13,7 +13,7 @@ lazy val docs = project
     // No resource directories shuts the ebean agent up about java sources in the classes directory
     unmanagedResourceDirectories in Test := Nil,
     parallelExecution in Test := false,
-    scalaVersion := "2.12.4"
+    scalaVersion := "2.12.6"
   )
   .settings(PlayEbean.unscopedSettings: _*)
   .settings(inConfig(Test)(Seq(

--- a/docs/project/plugins.sbt
+++ b/docs/project/plugins.sbt
@@ -4,4 +4,4 @@ lazy val sbtPlayEbean = ProjectRef(Path.fileProperty("user.dir").getParentFile, 
 
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 
-addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.6.13"))
+addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.7.0-M1"))

--- a/play-ebean/src/main/java/play/db/ebean/EbeanParsedConfig.java
+++ b/play-ebean/src/main/java/play/db/ebean/EbeanParsedConfig.java
@@ -5,7 +5,6 @@ package play.db.ebean;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueType;
-import play.Configuration;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -32,19 +31,6 @@ public class EbeanParsedConfig {
 
     public Map<String, List<String>> getDatasourceModels() {
         return datasourceModels;
-    }
-
-    /**
-     * Parse a play configuration.
-     *
-     * @param configuration play configuration
-     * @return ebean parsed configuration
-     *
-     * @deprecated {@link play.Configuration} was deprecated in Play 2.6 in favor of {@link com.typesafe.config.Config}. Use {@link #parseFromConfig(Config)}
-     */
-    @Deprecated
-    public static EbeanParsedConfig parseFromConfig(Configuration configuration) {
-        return parseFromConfig(configuration.underlying());
     }
 
     /**

--- a/play-ebean/src/main/java/play/db/ebean/ModelsConfigLoader.java
+++ b/play-ebean/src/main/java/play/db/ebean/ModelsConfigLoader.java
@@ -4,7 +4,8 @@
 
 package play.db.ebean;
 
-import play.Configuration;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import play.Environment;
 import play.Mode;
 
@@ -24,7 +25,7 @@ public class ModelsConfigLoader implements Function<ClassLoader, Map<String, Lis
     public  Map<String, List<String>> apply(ClassLoader classLoader) {
         // Using TEST mode is the only way to load configuration without failing if application.conf doesn't exist
         Environment env = new Environment(new File("."), classLoader, Mode.TEST);
-        Configuration config = Configuration.load(env);
+        Config config  = ConfigFactory.load(env.classLoader());
         return EbeanParsedConfig.parseFromConfig(config).getDatasourceModels();
     }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("1.3.15"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("2.0.3"))
 
 addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.0.2")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("1.3.12"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("1.3.15"))
 
 addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.0.2")
 

--- a/sbt-play-ebean/src/sbt-test/sbt-ebean/enhancement/build.sbt
+++ b/sbt-play-ebean/src/sbt-test/sbt-ebean/enhancement/build.sbt
@@ -2,7 +2,7 @@ lazy val root = project
   .in(file("."))
   .enablePlugins(PlayJava, PlayEbean)
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.6"
 
 sourceDirectory in Test := baseDirectory.value / "tests"
 

--- a/sbt-play-ebean/src/sbt-test/sbt-ebean/model-loading/build.sbt
+++ b/sbt-play-ebean/src/sbt-test/sbt-ebean/model-loading/build.sbt
@@ -2,7 +2,7 @@ lazy val root = project
   .in(file("."))
   .enablePlugins(PlayJava, PlayEbean)
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.6"
 
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 


### PR DESCRIPTION
Also updates to the latest version of Ebean.

I've copied `play.libs.Classpath` helper class, which was removed in Play 2.7, to here. It was not used in Play itself anymore, but it is useful for Play Ebean.