### PR TITLE
feat: upgrade to play 2.8.1 & ebean 11.45.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,6 @@ env:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    # Java 11 is not fully supported, but this allows for problem discovery
-    - env: SCRIPT="sbt +jacoco"                                     TRAVIS_JDK=11
-    - env: SCRIPT="sbt +publishLocal +plugin/test +plugin/scripted" TRAVIS_JDK=11
-    - env: SCRIPT="cd docs && sbt test"                             TRAVIS_JDK=11
-    - env: SCRIPT="cd docs && sbt validateDocs evaluateSbtFiles"    TRAVIS_JDK=11
 
 before_install:
   - curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Play Ebean plugin supports several different versions of Play and Ebean.
 
 | Plugin version | Play version | Ebean version |
 |----------------|--------------|---------------|
-| 6.0.0          | 2.8.0        | 11.45.1       |
+| 6.0.0          | 2.8.1        | 11.45.1       |
 | 5.0.2          | 2.7.0        | 11.39.x       |
 | 5.0.1          | 2.7.0        | 11.32.x       |
 | 5.0.0          | 2.7.0        | 11.22.x       |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The Play Ebean plugin supports several different versions of Play and Ebean.
 
 | Plugin version | Play version | Ebean version |
 |----------------|--------------|---------------|
+| 6.0.0          | 2.8.0        | 11.45.1       |
 | 5.0.2          | 2.7.0        | 11.39.x       |
 | 5.0.1          | 2.7.0        | 11.32.x       |
 | 5.0.0          | 2.7.0        | 11.22.x       |

--- a/build.sbt
+++ b/build.sbt
@@ -3,11 +3,11 @@ import interplay.ScalaVersions.scala212
 
 val scala213 = "2.13.0"
 val Versions = new {
-  val play: String = playVersion(sys.props.getOrElse("play.version", "2.7.3"))
+  val play: String = playVersion(sys.props.getOrElse("play.version", "2.8.0"))
   val playEnhancer = "1.2.2"
-  val ebean = "11.33.2"
-  val ebeanAgent = "11.27.1"
-  val typesafeConfig = "1.3.3"
+  val ebean = "11.45.1"
+  val ebeanAgent = "11.45.1"
+  val typesafeConfig = "1.3.4"
 }
 
 lazy val root = project
@@ -15,6 +15,7 @@ lazy val root = project
   .enablePlugins(PlayRootProject, CrossPerProjectPlugin)
   .aggregate(core, plugin)
   .settings(
+    sources in (Compile, doc) := Seq(),
     name := "play-ebean-root",
     releaseCrossBuild := false
   )
@@ -23,6 +24,7 @@ lazy val core = project
   .in(file("play-ebean"))
   .enablePlugins(Playdoc, PlayLibrary, JacocoPlugin)
   .settings(
+    sources in (Compile, doc) := Seq(),
     name := "play-ebean",
     crossScalaVersions := Seq(scala212, scala213),
     libraryDependencies ++= playEbeanDeps,
@@ -39,6 +41,7 @@ lazy val plugin = project
   .in(file("sbt-play-ebean"))
   .enablePlugins(PlaySbtPlugin)
   .settings(
+    sources in (Compile, doc) := Seq(),
     name := "sbt-play-ebean",
     organization := "com.typesafe.sbt",
     libraryDependencies ++= sbtPlayEbeanDeps,

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import interplay.ScalaVersions.scala212
 
 val scala213 = "2.13.0"
 val Versions = new {
-  val play: String = playVersion(sys.props.getOrElse("play.version", "2.8.0"))
+  val play: String = playVersion(sys.props.getOrElse("play.version", "2.8.1"))
   val playEnhancer = "1.2.2"
   val ebean = "11.45.1"
   val ebeanAgent = "11.45.1"

--- a/play-ebean/src/test/java/play/db/ebean/EBeanComponentsTest.java
+++ b/play-ebean/src/test/java/play/db/ebean/EBeanComponentsTest.java
@@ -27,7 +27,7 @@ public class EBeanComponentsTest {
 
         @Override
         public play.routing.Router router() {
-            return routingDsl().GET("/").routeTo(() ->
+            return routingDsl().GET("/").routingTo((req) ->
                     Results.ok("Hello")
             ).build();
         }

--- a/sbt-play-ebean/src/main/scala-sbt-0.13/play/ebean/sbt/PlayEbean.scala
+++ b/sbt-play-ebean/src/main/scala-sbt-0.13/play/ebean/sbt/PlayEbean.scala
@@ -40,7 +40,8 @@ object PlayEbean extends AutoPlugin {
     playEbeanDebugLevel := -1,
     playEbeanAgentArgs := Map("debug" -> playEbeanDebugLevel.value.toString),
     playEbeanVersion := readResourceProperty("play-ebean.version.properties", "play-ebean.version"),
-    libraryDependencies += "com.typesafe.play" %% "play-ebean" % playEbeanVersion.value
+    libraryDependencies += "com.typesafe.play" %% "play-ebean" % playEbeanVersion.value,
+    libraryDependencies += "org.glassfish.jaxb" % "jaxb-runtime" % "2.3.2"
   )
 
   def ebeanEnhance: Def.Initialize[Task[Compiler.CompileResult]] = Def.task {

--- a/sbt-play-ebean/src/main/scala-sbt-1.0/sbt/PlayEbean.scala
+++ b/sbt-play-ebean/src/main/scala-sbt-1.0/sbt/PlayEbean.scala
@@ -6,21 +6,16 @@ package play.ebean.sbt
 
 import io.ebean.enhance.Transformer
 import io.ebean.enhance.ant.OfflineFileTransform
-
 import sbt._
-import sbt.Keys._
-
+import sbt.Keys.{libraryDependencies, _}
 import xsbti.compile.CompileResult
 import xsbti.compile.analysis.Stamp
-
 import sbt.internal.inc.Hash
 import sbt.internal.inc.Stamper
 import sbt.internal.inc.LastModified
-
 import java.net.URLClassLoader
 
 import scala.util.control.NonFatal
-
 import com.typesafe.play.sbt.enhancer.PlayEnhancer
 
 object PlayEbean extends AutoPlugin {
@@ -50,7 +45,8 @@ object PlayEbean extends AutoPlugin {
     playEbeanDebugLevel := -1,
     playEbeanAgentArgs := Map("debug" -> playEbeanDebugLevel.value.toString),
     playEbeanVersion := readResourceProperty("play-ebean.version.properties", "play-ebean.version"),
-    libraryDependencies += "com.typesafe.play" %% "play-ebean" % playEbeanVersion.value
+    libraryDependencies += "com.typesafe.play" %% "play-ebean" % playEbeanVersion.value,
+    libraryDependencies += "org.glassfish.jaxb" % "jaxb-runtime" % "2.3.2"
   )
 
   // This is replacement of old Stamp `Exists` representation

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.0.3-SNAPSHOT"
+version in ThisBuild := "6.0.0"


### PR DESCRIPTION
- Upgrade to play 2.8.0
- Upgrade to ebean 11.45.1
- Included jaxb as a transitive dependency, since ebean requires it and if not included then this plugin will not work out of the box with Java 11