### PR TITLE
Rename master branch to main

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ stages:
   - name: jacoco
   - name: test
   - name: release
-    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
+    if: ((branch = main AND type = push) OR (tag IS present)) AND NOT fork
 
 jobs:
   include:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # play-ebean
 
-[![Build Status](https://travis-ci.com/playframework/play-ebean.svg?branch=master)](https://travis-ci.com/playframework/play-ebean)
+[![Build Status](https://travis-ci.com/playframework/play-ebean.svg?branch=main)](https://travis-ci.com/playframework/play-ebean)
 [![Maven](https://img.shields.io/maven-central/v/com.typesafe.play/play-ebean_2.12.svg)](http://mvnrepository.com/artifact/com.typesafe.play/play-ebean_2.12)
 
 This module provides Ebean support for Play Framework.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-This is released from the `master` branch unless it is a version older than `6.1.0`. If there is no branch for the
+This is released from the `main` branch unless it is a version older than `6.1.0`. If there is no branch for the
 release that needs patching, create it from the tag.
 
 ## Cutting the release
@@ -8,7 +8,7 @@ release that needs patching, create it from the tag.
 ### Requires contributor access
 
 - Check the [draft release notes](https://github.com/playframework/play-ebean/releases) to see if everything is there
-- Wait until [master build finished](https://travis-ci.com/github/playframework/play-ebean/builds) after merging the
+- Wait until [main build finished](https://travis-ci.com/github/playframework/play-ebean/builds) after merging the
   last PR
 - Update the [draft release](https://github.com/playframework/play-ebean/releases) with the next tag version
   (eg. `7.0.0`), title and release description


### PR DESCRIPTION
@SethTisue and @ihostage already renamed the `master` branch in some play repos:
* https://github.com/playframework/cachecontrol/pull/163
* https://github.com/playframework/play-file-watch/pull/136
* https://github.com/playframework/play-json/pull/598
* https://github.com/playframework/play-soap/pull/282
* https://github.com/playframework/play-ws/pull/597
* https://github.com/playframework/twirl/pull/416

Now that we are centralising configs in the [`.github`](https://github.com/playframework/.github) repo it's a good idea that all repos have the same default branch name.

To change to `main` locally (if the remote to this repo is called `upstream`):
```sh
git branch -m master main # rename master to main (actually "move")
git fetch upstream
git branch -u upstream/main main # set upstream
git remote set-head upstream -a # make sure HEAD is set correctly for this remote (autodetect)
```