### PR TITLE
Fix Scalafmt config

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,7 +1,7 @@
-align = true
+align.preset = true
 assumeStandardLibraryStripMargin = true
-danglingParentheses = true
-docstrings = JavaDoc
+danglingParentheses.preset = true
+docstrings.style = Asterisk
 maxColumn = 120
 project.git = true
 rewrite.rules = [ AvoidInfix, ExpandImportSelectors, RedundantParens, SortModifiers, PreferCurlyFors ]
@@ -9,4 +9,5 @@ rewrite.sortModifiers.order = [ "private", "protected", "final", "sealed", "abst
 spaces.inImportCurlyBraces = true   # more idiomatic to include whitepsace in import x.{ yyy }
 trailingCommas = preserve
 newlines.afterCurlyLambda = preserve
+runner.dialect = scala212source3
 version = 3.5.2

--- a/sbt-play-ebean/src/main/scala-sbt-1.0/play/ebean/sbt/PlayEbean.scala
+++ b/sbt-play-ebean/src/main/scala-sbt-1.0/play/ebean/sbt/PlayEbean.scala
@@ -41,15 +41,15 @@ object PlayEbean extends AutoPlugin {
 
   def scopedSettings =
     Seq(
-      playEbeanModels := configuredEbeanModels.value,
+      playEbeanModels    := configuredEbeanModels.value,
       manipulateBytecode := ebeanEnhance.value
     )
 
   def unscopedSettings =
     Seq(
       playEbeanDebugLevel := -1,
-      playEbeanAgentArgs := Map("debug" -> playEbeanDebugLevel.value.toString),
-      playEbeanVersion := readResourceProperty("play-ebean.version.properties", "play-ebean.version"),
+      playEbeanAgentArgs  := Map("debug" -> playEbeanDebugLevel.value.toString),
+      playEbeanVersion    := readResourceProperty("play-ebean.version.properties", "play-ebean.version"),
       libraryDependencies ++=
         Seq(
           "com.typesafe.play" %% "play-ebean"   % playEbeanVersion.value,
@@ -98,9 +98,8 @@ object PlayEbean extends AutoPlugin {
       val converter   = new PlainVirtualFileConverter()
 
       /**
-       * Updates stamp of product (class file) by preserving the type of a passed stamp.
-       * This way any stamp incremental compiler chooses to use to mark class files will
-       * be supported.
+       * Updates stamp of product (class file) by preserving the type of a passed stamp. This way any stamp incremental
+       * compiler chooses to use to mark class files will be supported.
        */
       def updateStampForClassFile(fileRef: VirtualFileRef, stamp: Stamp): Stamp =
         stamp match {
@@ -144,7 +143,7 @@ object PlayEbean extends AutoPlugin {
         } catch {
           case e: Exception =>
             // Since we're about to close the classloader, we can't risk any classloading that the thrown exception may
-            // do when we later interogate it, so instead we create a new exception here, with the old exceptions message
+            // do when we later interrogate it, so instead we create a new exception here, with the old exceptions message
             // and stack trace
             def clone(t: Throwable): RuntimeException = {
               val cloned = new RuntimeException(s"${t.getClass.getName}: ${t.getMessage}")
@@ -181,7 +180,7 @@ object PlayEbean extends AutoPlugin {
     try {
       props.load(stream)
     } catch {
-      case e: Exception =>
+      case _: Exception =>
     } finally {
       if (stream ne null) stream.close()
     }


### PR DESCRIPTION
After update Scalafmt to 3.5.2 it has broken config
I fixed that and successfully run `scalafmtCheck`
Without this error appeared:
```
sbt:play-ebean-root> scalafmtAll
[error] stack trace is suppressed; run 'last core / Test / scalafmt' for the full output
[error] stack trace is suppressed; run 'last core / Compile / scalafmt' for the full output
[error] stack trace is suppressed; run 'last plugin / Compile / scalafmt' for the full output
[error] (core / Test / scalafmt) org.scalafmt.sbt.ScalafmtSbtReporter$ScalafmtSbtError: scalafmt: Invalid config: 3 errors
[error] [E0] D:\Documents\GitHub\play-ebean\.scalafmt.conf:4:0 error: Type mismatch;
[error]   found    : String (value: "JavaDoc")
[error]   expected : Object
[error] docstrings = JavaDoc
[error] ^
[error]
[error] [E1] Presets$: top-level presets removed since v3.0.0; use 'danglingParentheses.preset = true' instead
[error] [E2] Presets$: top-level presets removed since v3.0.0; use 'align.preset = true' instead
[error]  [D:\Documents\GitHub\play-ebean\.scalafmt.conf]
[error] (core / Compile / scalafmt) org.scalafmt.sbt.ScalafmtSbtReporter$ScalafmtSbtError: scalafmt: Invalid config: 3 errors
[error] [E0] D:\Documents\GitHub\play-ebean\.scalafmt.conf:4:0 error: Type mismatch;
[error]   found    : String (value: "JavaDoc")
[error]   expected : Object
[error] docstrings = JavaDoc
[error] ^
[error]
[error] [E1] Presets$: top-level presets removed since v3.0.0; use 'danglingParentheses.preset = true' instead
[error] [E2] Presets$: top-level presets removed since v3.0.0; use 'align.preset = true' instead
[error]  [D:\Documents\GitHub\play-ebean\.scalafmt.conf]
[error] (plugin / Compile / scalafmt) org.scalafmt.sbt.ScalafmtSbtReporter$ScalafmtSbtError: scalafmt: Invalid config: 3 errors
[error] [E0] D:\Documents\GitHub\play-ebean\.scalafmt.conf:4:0 error: Type mismatch;
[error]   found    : String (value: "JavaDoc")
[error]   expected : Object
[error] docstrings = JavaDoc
[error] ^
[error]
[error] [E1] Presets$: top-level presets removed since v3.0.0; use 'danglingParentheses.preset = true' instead
[error] [E2] Presets$: top-level presets removed since v3.0.0; use 'align.preset = true' instead
[error]  [D:\Documents\GitHub\play-ebean\.scalafmt.conf]
[error] Total time: 2 s, completed 3 ╨╝╨░╤П 2022 ╨│., 23:57:23
```
After fixing these errors:
```
sbt:play-ebean-root> scalafmtAll
[error] stack trace is suppressed; run 'last core / Test / scalafmt' for the full output
[error] stack trace is suppressed; run 'last core / Compile / scalafmt' for the full output
[error] stack trace is suppressed; run 'last plugin / Compile / scalafmt' for the full output
[error] (core / Test / scalafmt) org.scalafmt.sbt.ScalafmtSbtReporter$ScalafmtSbtError: scalafmt: Invalid config: Default dialect is deprecated; use explicit: [sbt0137,sbt1,scala211,scala212,scala212source3,scala213,scala213source3,scala3]
[error] Also see https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects"
[error]  [D:\Documents\GitHub\play-ebean\.scalafmt.conf]
[error] (core / Compile / scalafmt) org.scalafmt.sbt.ScalafmtSbtReporter$ScalafmtSbtError: scalafmt: Invalid config: Default dialect is deprecated; use explicit: [sbt0137,sbt1,scala211,scala212,scala212source3,scala213,scala213source3,scala3]
[error] Also see https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects"
[error]  [D:\Documents\GitHub\play-ebean\.scalafmt.conf]
[error] (plugin / Compile / scalafmt) org.scalafmt.sbt.ScalafmtSbtReporter$ScalafmtSbtError: scalafmt: Invalid config: Default dialect is deprecated; use explicit: [sbt0137,sbt1,scala211,scala212,scala212source3,scala213,scala213source3,scala3]
[error] Also see https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects"
[error]  [D:\Documents\GitHub\play-ebean\.scalafmt.conf]
[error] Total time: 0 s, completed 4 ╨╝╨░╤П 2022 ╨│., 0:01:11
```
Link:
https://scalameta.org/scalafmt/docs/configuration.html