### PR TITLE
Switch to Jakarta persistence

### DIFF
--- a/docs/manual/working/javaGuide/main/sql/code/javaguide/ebean/Task.java
+++ b/docs/manual/working/javaGuide/main/sql/code/javaguide/ebean/Task.java
@@ -3,7 +3,7 @@
 package javaguide.ebean;
 
 import java.util.*;
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import io.ebean.*;
 import play.data.format.*;

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,13 +12,14 @@ object Dependencies {
 
   object Versions {
     val play: String   = "2.9.0-M4"
-    val ebean          = "13.17.2"
+    val ebean          = "13.17.3"
+    val ebeanJakarta   = s"$ebean-jakarta"
     val typesafeConfig = "1.4.2"
   }
 
   val ebean = libraryDependencies ++= Seq(
-    "io.ebean"           % "ebean"                % Versions.ebean,
-    "io.ebean"           % "ebean-ddl-generator"  % Versions.ebean,
+    "io.ebean"           % "ebean"                % Versions.ebeanJakarta,
+    "io.ebean"           % "ebean-ddl-generator"  % Versions.ebeanJakarta,
     "io.ebean"           % "ebean-agent"          % Versions.ebean,
     "com.typesafe.play" %% "play-java-jdbc"       % Versions.play,
     "com.typesafe.play" %% "play-jdbc-evolutions" % Versions.play,
@@ -31,7 +32,7 @@ object Dependencies {
   )
 
   val plugin = libraryDependencies ++= Seq(
-    "io.ebean"     % "ebean"       % Versions.ebean,
+    "io.ebean"     % "ebean"       % Versions.ebeanJakarta,
     "io.ebean"     % "ebean-agent" % Versions.ebean,
     "com.typesafe" % "config"      % Versions.typesafeConfig,
   )

--- a/sbt-play-ebean/src/sbt-test/sbt-ebean/enhancement/app/models/Task.java
+++ b/sbt-play-ebean/src/sbt-test/sbt-ebean/enhancement/app/models/Task.java
@@ -1,7 +1,7 @@
 package models;
 
 import java.util.*;
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import io.ebean.*;
 import play.data.format.*;


### PR DESCRIPTION
Let's see. IMHO makes sense since basically everyone is switching over recently. Planning to do the same with Play-Java-JPA:
* https://github.com/playframework/playframework/pull/11079

Switches from `javax.persistence` to `jakarta.persistence`.
See 
* https://github.com/ebean-orm/ebean/issues/2835#issuecomment-1449343867
  > As release `13.14.0` onwards we will additionally release a Jakarta version, so we have released `13-14.0-jakarta` version of the various ebean modules.
* https://github.com/ebean-orm/ebean/issues/2920
* https://github.com/ebean-orm/ebean/discussions/2839
* https://repo1.maven.org/maven2/io/ebean/ebean/