### PR TITLE
Respect `play.evolutions[.db.default].path` config for dynamic evolutions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,9 @@ lazy val mimaSettings = Seq(
   },
   mimaBinaryIssueFilters ++= Seq(
     // https://github.com/playframework/play-ebean/pull/281 - Removed io.ebean.EbeanServer in Ebean 13.6.0
-    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.db.ebean.EbeanDynamicEvolutions.generateEvolutionScript")
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.db.ebean.EbeanDynamicEvolutions.generateEvolutionScript"),
+    // https://github.com/playframework/play-ebean/pull/387 - Respect `play.evolutions[.db.default].path` config for dynamic evolutions
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.db.ebean.EbeanDynamicEvolutions.this"),
   )
 )
 

--- a/play-ebean/src/main/java/play/db/ebean/EBeanComponents.java
+++ b/play-ebean/src/main/java/play/db/ebean/EBeanComponents.java
@@ -4,7 +4,9 @@
 
 package play.db.ebean;
 
+import play.api.db.evolutions.DefaultEvolutionsConfigParser;
 import play.api.db.evolutions.DynamicEvolutions;
+import play.api.db.evolutions.EvolutionsConfig;
 import play.components.ConfigurationComponents;
 import play.db.DBComponents;
 
@@ -12,10 +14,15 @@ import play.db.DBComponents;
 public interface EBeanComponents extends ConfigurationComponents, DBComponents {
 
   default DynamicEvolutions dynamicEvolutions() {
-    return new EbeanDynamicEvolutions(ebeanConfig(), environment(), applicationLifecycle());
+    return new EbeanDynamicEvolutions(
+        ebeanConfig(), environment(), applicationLifecycle(), evolutionsConfig());
   }
 
   default EbeanConfig ebeanConfig() {
     return new DefaultEbeanConfig.EbeanConfigParser(config(), environment(), dbApi()).get();
+  }
+
+  default EvolutionsConfig evolutionsConfig() {
+    return new DefaultEvolutionsConfigParser(configuration()).parse();
   }
 }


### PR DESCRIPTION
Now that https://github.com/playframework/playframework/pull/11917 got merged we should respect that config.