### PR TITLE
Group Scala Steward patch updates into single PR

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,10 @@
 pullRequests.frequency = "@monthly"
+
 commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"
+
+pullRequests.grouping = [
+  { name = "patches", "title" = "Patch updates", "filter" = [{"version" = "patch"}] }
+]
 
 buildRoots = [
   ".",


### PR DESCRIPTION
Patch updates are likey to not break anything so we can just put them into one PR.