### PR TITLE
Skip connection for datasources with omitted db configuration

### DIFF
--- a/play-ebean/src/main/java/play/db/ebean/DefaultEbeanConfig.java
+++ b/play-ebean/src/main/java/play/db/ebean/DefaultEbeanConfig.java
@@ -18,6 +18,7 @@ import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 import org.reflections.util.FilterBuilder;
 import play.Environment;
+import play.Logger;
 import play.db.DBApi;
 
 /** Ebean server configuration. */
@@ -49,6 +50,8 @@ public class DefaultEbeanConfig implements EbeanConfig {
     private final Environment environment;
     private final DBApi dbApi;
 
+    private static final Logger.ALogger LOGGER = Logger.of(DefaultEbeanConfig.class);
+
     @Inject
     public EbeanConfigParser(Config config, Environment environment, DBApi dbApi) {
       this.config = config;
@@ -74,6 +77,12 @@ public class DefaultEbeanConfig implements EbeanConfig {
 
       for (Map.Entry<String, List<String>> entry : ebeanConfig.getDatasourceModels().entrySet()) {
         String key = entry.getKey();
+
+        if (dbApi.getDatabase(key) == null) {
+          LOGGER.debug("There is an 'ebean.{}' but no 'db.{}' configuration", key, key);
+          LOGGER.info("Skipping connection for datasource '{}'", key);
+          continue;
+        }
 
         DatabaseConfig serverConfig = new DatabaseConfig();
         serverConfig.setName(key);


### PR DESCRIPTION
This change will prevent issue #402 by skipping the creation and registration of a `DatabaseConfig` for ebean datasources which have no db connection parameters configured.

With this PR, users are able to specify and enhance Ebean models for datasources that may not be available on application startup, or that may be connected at a later stage during runtime. The `ebean.<datasource>` configuration can be specified without the need to also specify `db.<datasource>`.

```hocon
play.evolutions.db.foo.enabled = false
ebean.foo = ["models.foo.*"]

// NOT CONFIGURED
// db.foo { 
// }
```


After a few tests, this seems to behave as I'd expect.
- Trying to query a model that was skipped will lead to the `DataSource user is null?` exception
- Once a connection is establised manually (see below), querying the model becomes possible

```java
// manually connect the datasource
final DataSourceConfig dsc = new DataSourceConfig();
dsc.setUsername("username");
dsc.setPassword("password");
dsc.setUrl(connectionString("localhost", "my_schema");
final DatabaseConfig databaseConfig = new DatabaseConfig();
databaseConfig.setDataSourceConfig(dsc);
databaseConfig.setName("foo");
databaseConfig.setDefaultServer(false);
DatabaseFactory.create(databaseConfig);
```

---

I added a Logger to print information about the server config being skipped. I was not able to find a reference on how this should be done, so I did it the same way I'd do it in a Play application, by using `play.Logger.ALogger`. Let me know if this needs change.